### PR TITLE
Fix build process caused by dependency

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,6 +61,8 @@ gulp.task('build-js-libs', function() {
       'node_modules/noty/js/noty/packaged/jquery.noty.packaged.js',
       'node_modules/bootstrap/dist/js/bootstrap.js',
       'node_modules/angular-route/angular-route.js',
+      'node_modules/moment/moment.js',
+      'node_modules/humanize-duration/humanize-duration.js',
       'node_modules/angular-timer/dist/angular-timer.js'
     ])
     .pipe(uglify())

--- a/package.json
+++ b/package.json
@@ -9,14 +9,16 @@
   "dependencies": {
     "angular": "^1.4.0",
     "angular-route": "^1.4.0",
-    "angular-timer": "^1.2.0",
+    "angular-timer": "^1.3.0",
     "bootstrap": "^3.3.4",
     "express": "^4.12.4",
     "jquery": "^2.1.4",
     "noty": "^2.3.5",
     "request": "^2.56.0",
     "socket.io": "^1.3.5",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "moment": "~2.10.6",
+    "humanize-duration": "~3.3.0"
   },
   "devDependencies": {
     "gulp": "^3.9.0",


### PR DESCRIPTION
Fixed broken dashboard build due to angular-timer requiring extra libraries
